### PR TITLE
Async support

### DIFF
--- a/mq_http_sdk/mq_async_http.py
+++ b/mq_http_sdk/mq_async_http.py
@@ -1,0 +1,140 @@
+# coding=utf-8
+import asyncio
+import ssl
+from logging import Logger
+from typing import Optional, Union
+
+import certifi
+
+import aiohttp
+from aiohttp.http_exceptions import BadStatusLine
+
+from .mq_exception import *
+
+DEFAULT_CONNECTION_TIMEOUT = 60
+DEFAULT_READ_TIMEOUT = 100
+
+
+class RequestInternal:
+    def __init__(self, method="", uri="", header=None, data=""):
+        if header == None:
+            header = {}
+        self.method = method
+        self.uri = uri
+        self.header = header
+        self.data = data
+
+    def __str__(self):
+        return "Method: %s\nUri: %s\nHeader: %s\nData: %s\n" % \
+               (self.method, self.uri, "\n".join(["%s: %s" % (k, v) for k, v in list(self.header.items())]), self.data)
+
+
+class ResponseInternal:
+    def __init__(self, status=0, header=None, data=""):
+        if header == None:
+            header = {}
+        self.status = status
+        self.header = header
+        self.data = data
+
+    def __str__(self):
+        return "Status: %s\nHeader: %s\nData: %s\n" % \
+               (self.status, "\n".join(["%s: %s" % (k, v) for k, v in list(self.header.items())]), self.data)
+
+
+class MQHTTPAsyncConnection:
+    def __init__(self, host: str, connection_timeout: int = DEFAULT_CONNECTION_TIMEOUT):
+        self.host = host
+        self.connection_timeout = connection_timeout
+        self.session = aiohttp.ClientSession(base_url=f"http://{host}", timeout=connection_timeout, raise_for_status=True)
+
+    async def renew_session(self):
+        if self.session and not self.session.closed:
+            await self.session.close()
+        self.session = aiohttp.ClientSession(base_url=f"http://{self.host}", timeout=self.connection_timeout,
+                                             raise_for_status=True)
+
+    def close(self):
+        if self.session and not self.session.closed:
+            await self.session.close()
+
+
+class MQHTTPSAsyncConnection:
+    def __init__(self, host: str, ca_cert: str):
+        self.host = host
+        self.ca_cert = ca_cert
+        ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        ssl_context.load_verify_locations(ca_cert)
+        self.connector = aiohttp.TCPConnector(ssl=ssl_context)
+        self.session = aiohttp.ClientSession(base_url=f"https://{host}", raise_for_status=True, connector=self.connector)
+
+    async def renew_session(self):
+        if self.session and not self.session.closed:
+            await self.session.close()
+        self.session = aiohttp.ClientSession(base_url=f"https://{self.host}", raise_for_status=True, connector=self.connector)
+
+    def close(self):
+        if self.session and not self.session.closed:
+            await self.session.close()
+
+
+class MQAsyncHttp:
+    def __init__(self, host: str, connection_timeout: Optional[int] = DEFAULT_CONNECTION_TIMEOUT, keep_alive: Optional[bool] = True, logger: Optional[Logger] = None, is_https: Optional[bool] = False, read_timeout: Optional[int] = DEFAULT_READ_TIMEOUT):
+        ca_cert = certifi.where()
+        self.is_https = ca_cert and is_https
+        self.timeout = aiohttp.ClientTimeout(sock_read=read_timeout, sock_connect=connection_timeout)
+        if self.is_https:
+            self.conn = MQHTTPSAsyncConnection(host, ca_cert=ca_cert)
+        else:
+            self.conn = MQHTTPAsyncConnection(host, connection_timeout=connection_timeout)
+        self.host = host
+        self.is_https = is_https
+        self.connection_timeout = connection_timeout
+        self.keep_alive = keep_alive
+        self.logger = logger
+        if self.logger:
+            self.logger.info("InitOnsHttp KeepAlive:%s ConnectionTime:%s" % (self.keep_alive, self.connection_timeout))
+
+    def set_log_level(self, log_level: Union[str, int]):
+        if self.logger:
+            self.logger.setLevel(log_level)
+
+    def close_log(self):
+        self.logger = None
+
+    def set_connection_timeout(self, connection_timeout: int):
+        self.connection_timeout = connection_timeout
+        if not self.is_https:
+            if self.conn and self.conn.session and not self.conn.session.closed:
+                asyncio.run(self.conn.session.close())
+            self.conn = MQHTTPAsyncConnection(self.host, connection_timeout=connection_timeout)
+
+    def set_keep_alive(self, keep_alive: bool):
+        self.keep_alive = keep_alive
+
+    def is_keep_alive(self):
+        return self.keep_alive
+
+    async def send_request(self, req_inter: RequestInternal) -> ResponseInternal:
+        try:
+            if self.logger:
+                self.logger.debug("SendRequest %s" % req_inter)
+            try:
+                async with self.conn.session.request(method=req_inter.method, url=req_inter.uri, data=req_inter.data,
+                                                     headers=req_inter.header, ssl=False,
+                                                     timout=self.timeout) as http_resp:
+                    resp_inter = ResponseInternal(status=http_resp.status, header=http_resp.headers, data=await http_resp.text())
+            except BadStatusLine:
+                await self.conn.renew_session()
+                async with self.conn.session.request(method=req_inter.method, url=req_inter.uri, data=req_inter.data,
+                                                     headers=req_inter.header, ssl=False,
+                                                     timout=self.timeout) as http_resp:
+                    resp_inter = ResponseInternal(status=http_resp.status, header=http_resp.headers, data=await http_resp.text())
+            if not self.is_keep_alive():
+                await self.conn.session.close()
+            if self.logger:
+                self.logger.debug("GetResponse %s" % resp_inter)
+            return resp_inter
+        except Exception as e:
+            await self.conn.session.close()
+            raise MQClientNetworkException("NetWorkException", str(e))  # raise netException

--- a/mq_http_sdk/mq_async_http.py
+++ b/mq_http_sdk/mq_async_http.py
@@ -50,7 +50,7 @@ class MQHTTPAsyncConnection:
     async def async_request(self, req_inter, timeout) -> ResponseInternal:
         if self.session and not self.session.closed:
             return await self._async_do_action(self.session, req_inter, timeout)
-        async with aiohttp.ClientSession(base_url=f"http://{self.host}", raise_for_status=True) as session:
+        async with aiohttp.ClientSession(base_url=f"http://{self.host}", raise_for_status=False) as session:
             return await self._async_do_action(session, req_inter, timeout)
 
     @staticmethod
@@ -65,7 +65,7 @@ class MQHTTPAsyncConnection:
     async def renew_session(self):
         if self.session and not self.session.closed:
             await self.session.close()
-        self.session = aiohttp.ClientSession(base_url=f"http://{self.host}", raise_for_status=True)
+        self.session = aiohttp.ClientSession(base_url=f"http://{self.host}", raise_for_status=False)
 
     async def close(self):
         if self.session and not self.session.closed:
@@ -84,7 +84,7 @@ class MQHTTPSAsyncConnection:
     async def async_request(self, req_inter, timeout) -> ResponseInternal:
         if self.session and not self.session.closed:
             return await self._async_do_action(self.session, req_inter, timeout)
-        async with aiohttp.ClientSession(base_url=f"https://{self.host}", raise_for_status=True,
+        async with aiohttp.ClientSession(base_url=f"https://{self.host}", raise_for_status=False,
                                          connector=self.connector) as session:
             return await self._async_do_action(session, req_inter, timeout)
 
@@ -100,7 +100,7 @@ class MQHTTPSAsyncConnection:
     async def renew_session(self):
         if self.session and not self.session.closed:
             await self.session.close()
-        self.session = aiohttp.ClientSession(base_url=f"https://{self.host}", raise_for_status=True, connector=self.connector)
+        self.session = aiohttp.ClientSession(base_url=f"https://{self.host}", raise_for_status=False, connector=self.connector)
 
     async def close(self):
         if self.session and not self.session.closed:

--- a/mq_http_sdk/mq_client.py
+++ b/mq_http_sdk/mq_client.py
@@ -6,6 +6,7 @@ import hashlib
 import hmac
 import platform
 from . import pkg_info
+from .mq_async_http import MQAsyncHttp
 from .mq_xml_handler import *
 from .mq_tool import *
 from .mq_http import *
@@ -43,6 +44,7 @@ class MQClient:
         self.logger = logger
         self.debug = debug
         self.http = MQHttp(self.host, logger=logger, is_https=self.is_https)
+        self.async_http = MQAsyncHttp(self.host, logger=logger, is_https=self.is_https)
         if self.logger:
             self.logger.info("InitClient Host:%s Version:%s" % (host, self.version))
 
@@ -99,19 +101,26 @@ class MQClient:
             MQLogger.validate_loglevel(log_level)
             self.logger.setLevel(log_level)
             self.http.set_log_level(log_level)
+            self.async_http.set_log_level(log_level)
 
     def close_log(self):
         self.logger = None
         self.http.close_log()
+        self.async_http.close_log()
 
     def set_connection_timeout(self, connection_timeout):
         self.http.set_connection_timeout(connection_timeout)
+        self.async_http.set_connection_timeout(connection_timeout)
 
     def set_keep_alive(self, keep_alive):
         self.http.set_keep_alive(keep_alive)
+        self.async_http.set_keep_alive(keep_alive)
 
     def close_connection(self):
         self.http.conn.close()
+
+    def async_close_connection(self):
+        await self.async_http.conn.close()
 
     def consume_message(self, req, resp):
         # check parameter
@@ -133,6 +142,42 @@ class MQClient:
 
         # send request
         resp_inter = self.http.send_request(req_inter)
+
+        # handle result, make response
+        resp.status = resp_inter.status
+        resp.header = resp_inter.header
+        self.check_status(resp_inter, resp)
+        if resp.error_data == "":
+            resp.message_list = ConsumeMessageDecoder.decode(resp_inter.data, resp.get_req_id())
+            if self.logger:
+                self.logger.info("ConsumeMessage RequestId:%s TopicName:%s WaitSeconds:%s BatchSize:%s Tag:%s MessageCount:%s \
+                    MessagesInfo\n%s" % (
+                    resp.get_req_id(), req.topic_name, req.wait_seconds, req.batch_size, req.message_tag, len(resp.message_list), \
+                    "\n".join([
+                        "MessageId:%s MessageBodyMD5:%s NextConsumeTime:%s ReceiptHandle:%s PublishTime:%s ConsumedTimes:%s" % \
+                        (msg.message_id, msg.message_body_md5, msg.next_consume_time, msg.receipt_handle,
+                         msg.publish_time, msg.consumed_times) for msg in resp.message_list])))
+
+    async def async_consume_message(self, req, resp):
+        # check parameter
+        ConsumeMessageValidator.validate(req)
+
+        # make request internal
+        req_url = "/%s/%s/%s?consumer=%s&numOfMessages=%s" % (URI_SEC_TOPIC, req.topic_name, URI_SEC_MESSAGE, req.consumer, req.batch_size)
+        if req.instance_id != "":
+            req_url += "&ns=%s" % req.instance_id
+        if req.wait_seconds != -1:
+            req_url += "&waitseconds=%s" % req.wait_seconds
+        if req.message_tag != "":
+            req_url += "&tag=%s" % req.message_tag
+        if req.trans != "":
+            req_url += "&trans=%s" % req.trans
+
+        req_inter = RequestInternal(req.method, req_url)
+        self.build_header(req, req_inter)
+
+        # send request
+        resp_inter = await self.http.send_request(req_inter)
 
         # handle result, make response
         resp.status = resp_inter.status
@@ -175,6 +220,32 @@ class MQClient:
             self.logger.info("AckMessage RequestId:%s TopicName:%s ReceiptHandles\n%s" % \
                              (resp.get_req_id(), req.topic_name, "\n".join(req.receipt_handle_list)))
 
+    async def async_ack_message(self, req, resp):
+        # check parameter
+        AckMessageValidator.validate(req)
+
+        # make request internal
+        req_url = "/%s/%s/%s?consumer=%s" % (URI_SEC_TOPIC, req.topic_name, URI_SEC_MESSAGE, req.consumer)
+        if req.instance_id != "":
+            req_url += "&ns=%s" % req.instance_id
+        if req.trans != "":
+            req_url += "&trans=%s" % req.trans
+
+        req_inter = RequestInternal(req.method, req_url)
+        req_inter.data = ReceiptHandlesEncoder.encode(req.receipt_handle_list)
+        self.build_header(req, req_inter)
+
+        # send request
+        resp_inter = await self.http.send_request(req_inter)
+
+        # handle result, make response
+        resp.status = resp_inter.status
+        resp.header = resp_inter.header
+        self.check_status(resp_inter, resp, AckMessageDecoder)
+        if self.logger:
+            self.logger.info("AckMessage RequestId:%s TopicName:%s ReceiptHandles\n%s" % \
+                             (resp.get_req_id(), req.topic_name, "\n".join(req.receipt_handle_list)))
+
     def publish_message(self, req, resp):
         # check parameter
         PublishMessageValidator.validate(req)
@@ -190,6 +261,33 @@ class MQClient:
 
         # send request
         resp_inter = self.http.send_request(req_inter)
+
+        # handle result, make response
+        resp.status = resp_inter.status
+        resp.header = resp_inter.header
+        self.check_status(resp_inter, resp)
+        if resp.error_data == "":
+            resp.message_id, resp.message_body_md5, resp.receipt_handle = PublishMessageDecoder.decode(resp_inter.data,
+                                                                                  resp.get_req_id())
+            if self.logger:
+                self.logger.info("PublishMessage RequestId:%s TopicName:%s MessageId:%s MessageBodyMD5:%s" % \
+                                 (resp.get_req_id(), req.topic_name, resp.message_id, resp.message_body_md5))
+
+    async def async_publish_message(self, req, resp):
+        # check parameter
+        PublishMessageValidator.validate(req)
+
+        # make request internal
+        req_url = "/%s/%s/%s" % (URI_SEC_TOPIC, req.topic_name, URI_SEC_MESSAGE)
+        if req.instance_id != "":
+            req_url += "?ns=%s" % req.instance_id
+
+        req_inter = RequestInternal(req.method, req_url)
+        req_inter.data = TopicMessageEncoder.encode(req)
+        self.build_header(req, req_inter)
+
+        # send request
+        resp_inter = await self.async_http.send_request(req_inter)
 
         # handle result, make response
         resp.status = resp_inter.status

--- a/mq_http_sdk/mq_client.py
+++ b/mq_http_sdk/mq_client.py
@@ -182,7 +182,7 @@ class MQClient:
         self.build_header(req, req_inter)
 
         # send request
-        resp_inter = await self.http.send_request(req_inter)
+        resp_inter = await self.async_http.send_request(req_inter)
 
         # handle result, make response
         resp.status = resp_inter.status
@@ -241,7 +241,7 @@ class MQClient:
         self.build_header(req, req_inter)
 
         # send request
-        resp_inter = await self.http.send_request(req_inter)
+        resp_inter = await self.async_http.send_request(req_inter)
 
         # handle result, make response
         resp.status = resp_inter.status
@@ -310,6 +310,7 @@ class MQClient:
     def build_header(self, req, req_inter):
         if self.http.is_keep_alive():
             req_inter.header["Connection"] = "Keep-Alive"
+        req_inter.header["content-type"] = ""
         if req_inter.data != "":
             req_inter.header["content-type"] = "text/xml;charset=UTF-8"
         req_inter.header["x-mq-version"] = self.version

--- a/mq_http_sdk/mq_client.py
+++ b/mq_http_sdk/mq_client.py
@@ -114,12 +114,17 @@ class MQClient:
 
     def set_keep_alive(self, keep_alive):
         self.http.set_keep_alive(keep_alive)
-        self.async_http.set_keep_alive(keep_alive)
 
     def close_connection(self):
         self.http.conn.close()
 
-    def async_close_connection(self):
+    async def async_close_connection(self):
+        await self.async_http.conn.close()
+
+    async def start_async_session(self):
+        await self.async_http.conn.renew_session()
+
+    async def close_async_session(self):
         await self.async_http.conn.close()
 
     def consume_message(self, req, resp):

--- a/mq_http_sdk/mq_consumer.py
+++ b/mq_http_sdk/mq_consumer.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 
 import sys
+from contextlib import asynccontextmanager
+
 from .mq_request import *
 from .mq_tool import *
 if sys.version > '3':
@@ -50,6 +52,14 @@ class MQConsumer:
         self.debuginfo(resp)
         return self.__batchrecv_resp2msg__(resp)
 
+    @asynccontextmanager
+    async def start_async_session(self):
+        await self.mq_client.start_async_session()
+        try:
+            yield
+        finally:
+            await self.mq_client.close_async_session()
+
     async def async_consume_message(self, batch_size=1, wait_seconds=-1):
         """ 消费消息
 
@@ -69,7 +79,7 @@ class MQConsumer:
         """
         req = ConsumeMessageRequest(self.instance_id, self.topic_name, self.consumer, batch_size, self.message_tag, wait_seconds)
         resp = ConsumeMessageResponse()
-        await self.mq_client.consume_message(req, resp)
+        await self.mq_client.async_consume_message(req, resp)
         self.debuginfo(resp)
         return self.__batchrecv_resp2msg__(resp)
 
@@ -95,7 +105,7 @@ class MQConsumer:
         req = ConsumeMessageRequest(self.instance_id, self.topic_name, self.consumer, batch_size, self.message_tag, wait_seconds)
         req.set_order()
         resp = ConsumeMessageResponse()
-        await self.mq_client.consume_message(req, resp)
+        self.mq_client.consume_message(req, resp)
         self.debuginfo(resp)
         return self.__batchrecv_resp2msg__(resp)
 
@@ -121,7 +131,7 @@ class MQConsumer:
         req = ConsumeMessageRequest(self.instance_id, self.topic_name, self.consumer, batch_size, self.message_tag, wait_seconds)
         req.set_order()
         resp = ConsumeMessageResponse()
-        await self.mq_client.consume_message(req, resp)
+        await self.mq_client.async_consume_message(req, resp)
         self.debuginfo(resp)
         return self.__batchrecv_resp2msg__(resp)
 
@@ -154,7 +164,7 @@ class MQConsumer:
         """
         req = AckMessageRequest(self.instance_id, self.topic_name, self.consumer, receipt_handle_list)
         resp = AckMessageResponse()
-        await self.mq_client.ack_message(req, resp)
+        await self.mq_client.async_ack_message(req, resp)
         self.debuginfo(resp)
 
     def debuginfo(self, resp):

--- a/mq_http_sdk/mq_consumer.py
+++ b/mq_http_sdk/mq_consumer.py
@@ -53,7 +53,7 @@ class MQConsumer:
         return self.__batchrecv_resp2msg__(resp)
 
     @asynccontextmanager
-    async def start_async_session(self):
+    async def async_session(self):
         await self.mq_client.start_async_session()
         try:
             yield

--- a/mq_http_sdk/mq_consumer.py
+++ b/mq_http_sdk/mq_consumer.py
@@ -50,6 +50,29 @@ class MQConsumer:
         self.debuginfo(resp)
         return self.__batchrecv_resp2msg__(resp)
 
+    async def async_consume_message(self, batch_size=1, wait_seconds=-1):
+        """ 消费消息
+
+            @type batch_size: int
+            @param batch_size: 本次请求最多获取的消息条数，1~16
+
+            @type wait_seconds: int
+            @param wait_seconds: 本次请求的长轮询时间，单位：秒，1～30
+
+            @rtype: list of Message object
+            @return 多条消息的属性，包含消息的基本属性、下次可消费时间和临时句柄
+
+            @note: Exception
+            :: MQClientParameterException  参数格式异常
+            :: MQClientNetworkException    网络异常
+            :: MQServerException           处理异常
+        """
+        req = ConsumeMessageRequest(self.instance_id, self.topic_name, self.consumer, batch_size, self.message_tag, wait_seconds)
+        resp = ConsumeMessageResponse()
+        await self.mq_client.consume_message(req, resp)
+        self.debuginfo(resp)
+        return self.__batchrecv_resp2msg__(resp)
+
     def consume_message_orderly(self, batch_size=1, wait_seconds=-1):
         """ 顺序消费消息,拿到的消息可能是多个分区的（对于分区顺序）一个分区的内的消息一定是顺序的
             对于顺序消费，如果一个分区内的消息只要有没有被确认消费 {ack_message} 成功，则对于这个分区在NextConsumeTime后还会消费到相同的消息
@@ -72,7 +95,33 @@ class MQConsumer:
         req = ConsumeMessageRequest(self.instance_id, self.topic_name, self.consumer, batch_size, self.message_tag, wait_seconds)
         req.set_order()
         resp = ConsumeMessageResponse()
-        self.mq_client.consume_message(req, resp)
+        await self.mq_client.consume_message(req, resp)
+        self.debuginfo(resp)
+        return self.__batchrecv_resp2msg__(resp)
+
+    async def async_consume_message_orderly(self, batch_size=1, wait_seconds=-1):
+        """ 顺序消费消息,拿到的消息可能是多个分区的（对于分区顺序）一个分区的内的消息一定是顺序的
+            对于顺序消费，如果一个分区内的消息只要有没有被确认消费 {ack_message} 成功，则对于这个分区在NextConsumeTime后还会消费到相同的消息
+            对于一个分区，只有所有消息确认消费成功才能消费下一批消息
+
+            @type batch_size: int
+            @param batch_size: 本次请求最多获取的消息条数，1~16
+
+            @type wait_seconds: int
+            @param wait_seconds: 本次请求的长轮询时间，单位：秒，1～30
+
+            @rtype: list of Message object
+            @return 多条消息的属性，包含消息的基本属性、下次可消费时间和临时句柄
+
+            @note: Exception
+            :: MQClientParameterException  参数格式异常
+            :: MQClientNetworkException    网络异常
+            :: MQServerException           处理异常
+        """
+        req = ConsumeMessageRequest(self.instance_id, self.topic_name, self.consumer, batch_size, self.message_tag, wait_seconds)
+        req.set_order()
+        resp = ConsumeMessageResponse()
+        await self.mq_client.consume_message(req, resp)
         self.debuginfo(resp)
         return self.__batchrecv_resp2msg__(resp)
 
@@ -90,6 +139,22 @@ class MQConsumer:
         req = AckMessageRequest(self.instance_id, self.topic_name, self.consumer, receipt_handle_list)
         resp = AckMessageResponse()
         self.mq_client.ack_message(req, resp)
+        self.debuginfo(resp)
+
+    async def async_ack_message(self, receipt_handle_list):
+        """确认消息消费成功，如果未在300秒内确认则认为消息消费失败，通过consume_message能再次收到改消息
+
+            @type receipt_handle_list: list, size: 1~16
+            @param receipt_handle_list: consume_message返回的多条消息的临时句柄
+
+            @note: Exception
+            :: MQClientParameterException  参数格式异常
+            :: MQClientNetworkException    网络异常
+            :: MQServerException           处理异常
+        """
+        req = AckMessageRequest(self.instance_id, self.topic_name, self.consumer, receipt_handle_list)
+        resp = AckMessageResponse()
+        await self.mq_client.ack_message(req, resp)
         self.debuginfo(resp)
 
     def debuginfo(self, resp):

--- a/mq_http_sdk/mq_producer.py
+++ b/mq_http_sdk/mq_producer.py
@@ -48,7 +48,7 @@ class MQProducer:
         return self.__publish_resp2msg__(resp)
 
     @asynccontextmanager
-    async def start_async_session(self):
+    async def async_session(self):
         await self.mq_client.start_async_session()
         try:
             yield

--- a/mq_http_sdk/mq_producer.py
+++ b/mq_http_sdk/mq_producer.py
@@ -46,6 +46,28 @@ class MQProducer:
         self.debuginfo(resp)
         return self.__publish_resp2msg__(resp)
 
+    async def async_publish_message(self, message):
+        """ 发送消息
+
+            @type message: TopicMessage object
+            @param message: 发布的TopicMessage object
+
+            @rtype: TopicMessage object
+            @return: 消息发布成功的返回属性，包含MessageId和MessageBodyMD5
+
+            @note: Exception
+            :: MQClientParameterException  参数格式异常
+            :: MQClientNetworkException    网络异常
+            :: MQServerException           处理异常
+        """
+        msg_properties_str = MQUtils.map_to_string(message.properties)
+        req = PublishMessageRequest(self.instance_id, self.topic_name, message.message_body, message.message_tag,
+                                    msg_properties_str)
+        resp = PublishMessageResponse()
+        await self.mq_client.publish_message(req, resp)
+        self.debuginfo(resp)
+        return self.__publish_resp2msg__(resp)
+
     def debuginfo(self, resp):
         if self.debug:
             print("===================DEBUG INFO===================")
@@ -159,6 +181,30 @@ class MQTransProducer(MQProducer):
         self.debuginfo(resp)
         return self.__batchrecv_resp2msg__(resp)
 
+    async def async_consume_half_message(self, batch_size=1, wait_seconds=-1):
+        """ 消费事务半消息
+
+            @type batch_size: int
+            @param batch_size: 本次请求最多获取的消息条数，1~16
+
+            @type wait_seconds: int
+            @param wait_seconds: 本次请求的长轮询时间，单位：秒，1～30
+
+            @rtype: list of Message object
+            @return 多条事务半消息消息，包含消息的基本属性、下次可消费时间和临时句柄
+
+            @note: Exception
+            :: MQClientParameterException  参数格式异常
+            :: MQClientNetworkException    网络异常
+            :: MQServerException           处理异常
+        """
+        req = ConsumeMessageRequest(self.instance_id, self.topic_name, self.group_id, batch_size, "", wait_seconds)
+        req.set_trans_pop()
+        resp = ConsumeMessageResponse()
+        await self.mq_client.consume_message(req, resp)
+        self.debuginfo(resp)
+        return self.__batchrecv_resp2msg__(resp)
+
     def commit(self, receipt_handle):
         """提交事务消息
 
@@ -176,6 +222,23 @@ class MQTransProducer(MQProducer):
         self.mq_client.ack_message(req, resp)
         self.debuginfo(resp)
 
+    async def async_commit(self, receipt_handle):
+        """提交事务消息
+
+            @type receipt_handle: basestring
+            @param receipt_handle: consume_half_message返回的单条消息句柄或者是发送事务消息返回的句柄
+
+            @note: Exception
+            :: MQClientParameterException  参数格式异常
+            :: MQClientNetworkException    网络异常
+            :: MQServerException           处理异常
+        """
+        req = AckMessageRequest(self.instance_id, self.topic_name, self.group_id, [receipt_handle])
+        req.set_trans_commit()
+        resp = AckMessageResponse()
+        await self.mq_client.ack_message(req, resp)
+        self.debuginfo(resp)
+
     def rollback(self, receipt_handle):
         """取消事务消息
 
@@ -191,6 +254,23 @@ class MQTransProducer(MQProducer):
         req.set_trans_rollback()
         resp = AckMessageResponse()
         self.mq_client.ack_message(req, resp)
+        self.debuginfo(resp)
+
+    async def async_rollback(self, receipt_handle):
+        """取消事务消息
+
+            @type receipt_handle: basestring
+            @param receipt_handle: consume_half_message返回的单条消息句柄或者是发送事务消息返回的句柄
+
+            @note: Exception
+            :: MQClientParameterException  参数格式异常
+            :: MQClientNetworkException    网络异常
+            :: MQServerException           处理异常
+        """
+        req = AckMessageRequest(self.instance_id, self.topic_name, self.group_id, [receipt_handle])
+        req.set_trans_rollback()
+        resp = AckMessageResponse()
+        await self.mq_client.ack_message(req, resp)
         self.debuginfo(resp)
 
     def __batchrecv_resp2msg__(self, resp):

--- a/mq_http_sdk/pkg_info.py
+++ b/mq_http_sdk/pkg_info.py
@@ -1,5 +1,5 @@
-name = "mq_http_sdk"
-version = "1.0.3"
+name = "async_mq_http_sdk"
+version = "1.0.5"
 url = "https://github.com/aliyunmq/mq-http-python-sdk"
 license = "MIT"
 short_description = "Aliyun Message Queue(MQ) Http Python SDK"

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ if sys.version_info <= (2, 5):
 
 setup(name=mq_http_sdk.pkg_info.name,
       version=mq_http_sdk.pkg_info.version,
+      install_requires=["aiohttp>=3.8.1"],
       author="aliyunmq",
       author_email="",
       url=mq_http_sdk.pkg_info.url,


### PR DESCRIPTION
Adding async support for MQ client

_On a simple test run, we got from 10K messages in ~50 minutes to 10K messages in under 1 min!_


```python
import asyncio

from mq_http_sdk.mq_client import MQClient
from mq_http_sdk.mq_producer import TopicMessage

topic_name = "Async-POC"
instance_id = "XXX"

mq_client = MQClient(host="XXX", access_id="XXX", access_key="XXX")

producer = mq_client.get_producer(instance_id, topic_name)

async def multi_publish_message():
    async with producer.async_session():
        await producer.async_publish_message(TopicMessage("This is async 1", message_tag="async1.1"))
        await producer.async_publish_message(TopicMessage("This is async 2", message_tag="async1.2"))

async def single_publish_message():
    await producer.async_publish_message(TopicMessage("This is async 3", message_tag="async1.3"))

asyncio.run(multi_publish_message())

asyncio.run(single_publish_message())
```